### PR TITLE
Get graphql query result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,10 +103,3 @@ public
 
 # TernJS port file
 .tern-port
-
-# Cypress
-cypress/screenshots
-cypress/videos
-cypress/support
-cypress/plugins
-cypress/fixtures

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,10 @@ public
 
 # TernJS port file
 .tern-port
+
+# Cypress
+cypress/screenshots
+cypress/videos
+cypress/support
+cypress/plugins
+cypress/fixtures

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -24,7 +24,7 @@ exports.onPostBuild = async function ({ graphql, reporter }, config) {
     const { data } = await graphql(indexes.query)
     console.log(data)
   } catch (err) {
-    reporter.error(err)
+    reporter.error(err.message)
     activity.setStatus('Failed to index to MeiliSearch')
   }
   activity.end()

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,24 +1,23 @@
-exports.pluginOptionsSchema = ({ Joi }) => {
-  return Joi.object({
-    host: Joi.string().required(),
-    apiKey: Joi.any(),
-    skipIndexing: Joi.any(),
-    indexes: Joi.object({
-      indexUid: Joi.any(),
-      query: Joi.string().required(),
-    }),
-  })
+const validatePluginOptions = config => {
+  if (!config.host) {
+    throw new Error(`gatsby-plugin-meilisearch: option "host" missing`)
+  }
+  if (!config.indexes || !config.indexes.query) {
+    throw new Error(`gatsby-plugin-meilisearch: option "indexes.query" missing`)
+  }
 }
 
 exports.onPostBuild = async function ({ graphql, reporter }, config) {
-  const activity = reporter.activityTimer(`Running gatsby-plugin-meilisearch`)
+  const activity = reporter.activityTimer(`gatsby-plugin-meilisearch`)
   activity.start()
   try {
+    validatePluginOptions(config)
     const { indexes } = config
     const { data } = await graphql(indexes.query)
     console.log(data)
   } catch (err) {
     reporter.error(err)
+    activity.setStatus('Failed to index to MeiliSearch')
   }
   activity.end()
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,17 +1,17 @@
 const PLUGIN_NAME = 'gatsby-plugin-meilisearch'
 
 const getValidationError = field =>
-  `[${PLUGIN_NAME}] Field "${field}" is not defined in the collection schema`
+  `[${PLUGIN_NAME}] The Field ${field} is required in the plugin configuration`
 
 const validatePluginOptions = (indexes, host) => {
   if (!host) {
-    throw new Error(getValidationError('host'))
+    throw getValidationError('host')
   }
   if (!indexes.query) {
-    throw new Error(getValidationError('indexes.query'))
+    throw getValidationError('query in the indexes object')
   }
   if (!indexes.indexUid) {
-    throw new Error(getValidationError('indexes.indexUid'))
+    throw getValidationError('indexUid in the indexes object')
   }
 }
 
@@ -24,7 +24,7 @@ exports.onPostBuild = async function ({ graphql, reporter }, config) {
     const { data } = await graphql(indexes.query)
     console.log(data)
   } catch (err) {
-    reporter.error(err.message)
+    reporter.error(err)
     activity.setStatus('Failed to index to MeiliSearch')
   }
   activity.end()

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -7,11 +7,13 @@ const validatePluginOptions = (indexes, host) => {
   if (!host) {
     throw getValidationError('host')
   }
-  if (!indexes.query) {
-    throw getValidationError('query in the indexes object')
-  }
-  if (!indexes.indexUid) {
-    throw getValidationError('indexUid in the indexes object')
+  if (typeof indexes !== 'undefined') {
+    if (!indexes.query) {
+      throw getValidationError('query in the indexes object')
+    }
+    if (!indexes.indexUid) {
+      throw getValidationError('indexUid in the indexes object')
+    }
   }
 }
 
@@ -19,7 +21,7 @@ exports.onPostBuild = async function ({ graphql, reporter }, config) {
   const activity = reporter.activityTimer(PLUGIN_NAME)
   activity.start()
   try {
-    const { indexes = {}, host } = config
+    const { indexes, host } = config
     validatePluginOptions(indexes, host)
     const { data } = await graphql(indexes.query)
     console.log(data)

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,7 +1,7 @@
 const PLUGIN_NAME = 'gatsby-plugin-meilisearch'
 
 const getValidationError = field =>
-  `[${PLUGIN_NAME}] The Field ${field} is required in the plugin configuration`
+  `[${PLUGIN_NAME}] The field ${field} is required in the plugin configuration`
 
 const validatePluginOptions = (indexes, host) => {
   if (!host) {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,18 +1,26 @@
-const validatePluginOptions = config => {
-  if (!config.host) {
-    throw new Error(`gatsby-plugin-meilisearch: option "host" missing`)
+const PLUGIN_NAME = 'gatsby-plugin-meilisearch'
+
+const getValidationError = field =>
+  `[${PLUGIN_NAME}] Field "${field}" is not defined in the collection schema`
+
+const validatePluginOptions = (indexes, host) => {
+  if (!host) {
+    throw new Error(getValidationError('host'))
   }
-  if (!config.indexes || !config.indexes.query) {
-    throw new Error(`gatsby-plugin-meilisearch: option "indexes.query" missing`)
+  if (!indexes.query) {
+    throw new Error(getValidationError('indexes.query'))
+  }
+  if (!indexes.indexUid) {
+    throw new Error(getValidationError('indexes.indexUid'))
   }
 }
 
 exports.onPostBuild = async function ({ graphql, reporter }, config) {
-  const activity = reporter.activityTimer(`gatsby-plugin-meilisearch`)
+  const activity = reporter.activityTimer(PLUGIN_NAME)
   activity.start()
   try {
-    validatePluginOptions(config)
-    const { indexes } = config
+    const { indexes = {}, host } = config
+    validatePluginOptions(indexes, host)
     const { data } = await graphql(indexes.query)
     console.log(data)
   } catch (err) {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -13,11 +13,11 @@ const validatePluginOptions = (queries, host) => {
   if (!isObject(queries)) {
     throw `[${PLUGIN_NAME}] The field "queries" must be of type object and contain the fields "query" and "indexUid"`
   }
-  if (!queries.query) {
-    throw getValidationError('"query" in the "queries" object')
-  }
   if (!queries.indexUid) {
     throw getValidationError('"indexUid" in the "queries" object')
+  }
+  if (!queries.query) {
+    throw getValidationError('"query" in the "queries" object')
   }
 }
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,17 +1,24 @@
-const path = require(`path`)
-
-// Creates a `test` page to test that the plugin and the playground are linked together
-exports.createPages = ({ actions }) => {
-  const { createPage } = actions
-  const blogPostTemplate = path.resolve(`src/components/blog-layout.js`)
-
-  createPage({
-    path: `test`,
-    component: blogPostTemplate,
-    context: {
-      frontmatter: {
-        title: 'Test page',
-      },
-    },
+exports.pluginOptionsSchema = ({ Joi }) => {
+  return Joi.object({
+    host: Joi.string().required(),
+    apiKey: Joi.any(),
+    skipIndexing: Joi.any(),
+    indexes: Joi.object({
+      indexUid: Joi.any(),
+      query: Joi.string().required(),
+    }),
   })
+}
+
+exports.onPostBuild = async function ({ graphql, reporter }, config) {
+  const activity = reporter.activityTimer(`Running gatsby-plugin-meilisearch`)
+  activity.start()
+  try {
+    const { indexes } = config
+    const { data } = await graphql(indexes.query)
+    console.log(data)
+  } catch (err) {
+    reporter.error(err)
+  }
+  activity.end()
 }

--- a/playground/gatsby-config.js
+++ b/playground/gatsby-config.js
@@ -37,6 +37,28 @@ module.exports = {
     },
     {
       resolve: require.resolve(`../`),
+      options: {
+        host: 'http://127.0.0.1:7700',
+        apiKey: 'masterKey',
+        skipIndexing: true,
+        indexes: {
+          indexUid: 'MyBlog',
+          query: `
+            query MyQuery {
+              allMdx {
+                edges {
+                  node {
+                    frontmatter {
+                      title
+                    }
+                    tableOfContents
+                  }
+                }
+              }
+            }
+          `,
+        },
+      },
     },
   ],
 }

--- a/playground/gatsby-config.js
+++ b/playground/gatsby-config.js
@@ -41,7 +41,7 @@ module.exports = {
         host: 'http://127.0.0.1:7700',
         apiKey: 'masterKey',
         skipIndexing: true,
-        indexes: {
+        queries: {
           indexUid: 'MyBlog',
           query: `
             query MyQuery {

--- a/playground/package.json
+++ b/playground/package.json
@@ -8,7 +8,7 @@
     "gatsby"
   ],
   "scripts": {
-    "develop": "gatsby develop --open",
+    "develop": "gatsby develop",
     "start": "gatsby develop",
     "build": "gatsby build",
     "serve": "gatsby serve",


### PR DESCRIPTION
Closes #6 

## What's inside this PR ? 

- Removal of the `createPages` example
- Rename of `indexes` into `queries`
- Addition of the `onPostBuild` function with the graphql query inside + log of the result.
- Addition of a `validatePluginOptions` function, to check that some mandatory options are present. If not, it logs an error without stopping the build.
- Removal of the `--open` for develop mode, as it switches me to the website tab on every change inside the plugin

## How to test

`yarn && yarn playground:dev`

## Error handling

- if `host` is missing -> error (stop plugin execution, without stopping the build)
- If `queries` is missing -> warning (continues the plugin execution)
- if `queries` has other type than `object` -> error (stop plugin execution, without stopping the build)
- if `queries` is present, but `queries.indexUid` or `queries.query` missing -> error (stop plugin execution, without stopping the build)

## Screenshots

Log of the retrieved data: 

![Capture d’écran 2021-07-19 à 14 21 36](https://user-images.githubusercontent.com/30866152/126159110-29a578ce-04be-4018-9bc9-c6ddad619d10.png)

Log of the error without stopping the build: 

<img width="619" alt="Capture d’écran 2021-07-21 à 16 44 54" src="https://user-images.githubusercontent.com/30866152/126508610-38cecbd2-9eae-46f9-bae7-4a5a5190e1fb.png">


