### PR TITLE
Index result query to meilisearch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,7 @@ typings/
 
 # dotenv environment variables file
 .env
-.env.test
+.env.*
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,13 +77,14 @@ You may also just want to generate a build without serving it. If so, run the fo
 yarn playground:build
 ```
 
-If you want to specify your host, API key and index name, you can do so by adding a `.env` file inside the playground folder.
-The following environement variables are provided :
+If you want to specify your host, API key and index name, you can do so by editing the `gatsby-config.js` file, as well as the `src/pages/index.js` file if you want to test the playground's front-end.
+You can also use the environment variables `GATSBY_MEILI_HTTP_ADDR`, `GATSBY_MEILI_MASTER_KEY`, and `GATSBY_MEILI_INDEX_NAME`. This can also be done with a `.env` file:
 
 ```bash
-GATSBY_MEILI_HTTP_ADDR
-GATSBY_MEILI_MASTER_KEY
-GATSBY_MEILI_INDEX_NAME
+// .env
+GATSBY_MEILI_HTTP_ADDR="http://localhost:7700"
+GATSBY_MEILI_MASTER_KEY="masterKey"
+GATSBY_MEILI_INDEX_NAME="myIndex"
 ```
 
 ## Git Guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,8 +81,8 @@ If you want to specify your host, API key and index name, you can do so by addin
 The following environement variables are provided :
 
 ```bash
-GATSBY_MEILI_SERVER_ADDRESS
-GATSBY_MEILI_API_KEY
+GATSBY_MEILI_HTTP_ADDR
+GATSBY_MEILI_MASTER_KEY
 GATSBY_MEILI_INDEX_NAME
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,10 +78,11 @@ yarn playground:build
 ```
 
 If you want to specify your host, API key and index name, you can do so by editing the `gatsby-config.js` file, as well as the `src/pages/index.js` file if you want to test the playground's front-end.
-You can also use the environment variables `GATSBY_MEILI_HTTP_ADDR`, `GATSBY_MEILI_MASTER_KEY`, and `GATSBY_MEILI_INDEX_NAME`. This can also be done with a `.env` file:
+Alternatively, you can set the environment variables `GATSBY_MEILI_HTTP_ADDR`, `GATSBY_MEILI_MASTER_KEY`, and `GATSBY_MEILI_INDEX_NAME`. It is possible to provide them in a `.env` file at the root of the playground.
+
+Example of `.env`:
 
 ```bash
-// .env
 GATSBY_MEILI_HTTP_ADDR="http://localhost:7700"
 GATSBY_MEILI_MASTER_KEY="masterKey"
 GATSBY_MEILI_INDEX_NAME="myIndex"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,14 @@ You may also just want to generate a build without serving it. If so, run the fo
 yarn playground:build
 ```
 
-Note that you might need to change the host and the API Key of your MeiliSearch client [here](./playground/src/pages/index.js).
+If you want to specify your host, API key and index name, you can do so by adding a `.env` file inside the playground folder.
+The following environement variables are provided :
+
+```bash
+GATSBY_MEILI_SERVER_ADDRESS
+GATSBY_MEILI_API_KEY
+GATSBY_MEILI_INDEX_NAME
+```
 
 ## Git Guidelines
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,57 @@ docker run -it --rm -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --mas
 
 ### Basic
 
+
+`gatsby-config.js`
+
+```node
+{
+  resolve: 'gatsby-plugin-meilisearch',
+  options: {
+    // Your MeiliSearch host
+    host: 'http://localhost:7700',
+    queries: {
+      // Your index name
+      indexUid: `my_blog`,
+      // Your transformer, to transform the data before sending it to MeiliSearch
+      transformer: data => data.allMdx.edges.map(({ node }) => node),
+      // Your query containing the data you want to retrieve and index
+      query: `
+        query MyQuery {
+          allMdx {
+            edges {
+              node {
+                id
+                slug
+                frontmatter {
+                  title
+                  cover
+                }
+                tableOfContents
+              }
+            }
+          }
+        }
+      `,
+    },
+  },
+}
+```
+
 ### Customization
+
+The plugin accepts the following options for further customization :
+```node
+{
+  resolve: 'gatsby-plugin-meilisearch',
+  options: {
+    // Your MeiliSearch API key
+    apiKey: process.env.GATSBY_MEILI_API_KEY,
+    skipIndexing: true, // Default to false
+  },
+}
+
+```
 
 ## 🤖 Compatibility with MeiliSearch and Gatsby
 

--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ docker run -it --rm -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --mas
 {
   resolve: 'gatsby-plugin-meilisearch',
   options: {
-    // Your MeiliSearch host
+    // Host on which your MeiliSearch instance is running
     host: 'http://localhost:7700',
     queries: {
-      // Your index name
+      // Index in which the content will be added
       indexUid: `my_blog`,
-      // Your transformer, to transform the data before sending it to MeiliSearch
+      // Function that transforms the fetched data before sending it to MeiliSearch
       transformer: data => data.allMdx.edges.map(({ node }) => node),
-      // Your query containing the data you want to retrieve and index
+      // graphQL query that fetches the data to index in MeiliSearch
       query: `
         query MyQuery {
           allMdx {
@@ -116,9 +116,9 @@ The plugin accepts the following options for further customization :
 {
   resolve: 'gatsby-plugin-meilisearch',
   options: {
-    // Your MeiliSearch API key
-    apiKey: process.env.GATSBY_MEILI_API_KEY,
-    skipIndexing: true, // Default to false
+    // API key if the MeiliSearch instance is password protected
+    apiKey: "masterKey",
+    skipIndexing: true, // Run script without indexing to MeiliSearch. Default to false
   },
 }
 

--- a/cypress/integration/home_page.specs.js
+++ b/cypress/integration/home_page.specs.js
@@ -9,21 +9,6 @@ describe(`Home page`, () => {
   it('Should have a title', () => {
     cy.contains('MeiliSearch + React InstantSearch + Gatsby')
   })
-  it('Should have an article list of 5 elements', () => {
-    cy.contains('Article List')
-    cy.get('.article-list li').should('have.length', 5)
-    cy.get('.article-list li')
-      .first()
-      .should('have.text', 'Axolotl')
-      .next()
-      .should('have.text', 'Immortal Jellyfish')
-      .next()
-      .should('have.text', 'Marmoset')
-      .next()
-      .should('have.text', 'Okapi')
-      .next()
-      .should('have.text', 'Shoebill')
-  })
   it('Should have a search bar', () => {
     cy.contains('Search in this blog’s articles')
     cy.get('input[type="search"]').should('be.visible')

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -45,7 +45,7 @@ exports.onPostBuild = async function ({ graphql, reporter }, config) {
     }
     validatePluginOptions(queries, host)
 
-    // Get graphQL data
+    // Fetch data with graphQL query
     const { data } = await graphql(queries.query)
 
     const client = new MeiliSearch({

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -56,8 +56,7 @@ exports.onPostBuild = async function ({ graphql, reporter }, config) {
     // Prepare data for indexation
     const transformedData = await queries.transformer(data)
 
-    // Create index
-    const index = await client.getOrCreateIndex(queries.indexUid)
+    const index = client.index(queries.indexUid)
 
     // Index data to MeiliSearch
     const { updateId } = await index.addDocuments(transformedData)

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -61,7 +61,7 @@ exports.onPostBuild = async function ({ graphql, reporter }, config) {
     // Index data to MeiliSearch
     const { updateId } = await index.addDocuments(transformedData)
 
-    // Check status
+    // Wait for indexation to be completed
     await index.waitForPendingUpdate(updateId)
     const res = await index.getUpdateStatus(updateId)
     if (res.status === 'failed') {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,3 +1,5 @@
+const { MeiliSearch } = require('meilisearch')
+
 const PLUGIN_NAME = 'gatsby-plugin-meilisearch'
 
 const isObject = obj =>
@@ -6,12 +8,16 @@ const isObject = obj =>
 const getValidationError = field =>
   `[${PLUGIN_NAME}] The field ${field} is required in the plugin configuration`
 
+const getErrorMsg = msg => `[${PLUGIN_NAME}] ${msg}`
+
 const validatePluginOptions = (queries, host) => {
   if (!host) {
     throw getValidationError('"host"')
   }
   if (!isObject(queries)) {
-    throw `[${PLUGIN_NAME}] The field "queries" must be of type object and contain the fields "query" and "indexUid"`
+    throw getErrorMsg(
+      'The field "queries" must be of type object and contain the following fields: "indexUid", "query", "transformer"'
+    )
   }
   if (!queries.indexUid) {
     throw getValidationError('"indexUid" in the "queries" object')
@@ -19,24 +25,53 @@ const validatePluginOptions = (queries, host) => {
   if (!queries.query) {
     throw getValidationError('"query" in the "queries" object')
   }
+  if (!queries.transformer) {
+    throw getValidationError('"transformer" in the "queries" object')
+  }
 }
 
 exports.onPostBuild = async function ({ graphql, reporter }, config) {
   const activity = reporter.activityTimer(PLUGIN_NAME)
   activity.start()
   try {
-    const { queries, host } = config
+    const { queries, host, apiKey = '' } = config
     if (!queries) {
       reporter.warn(
-        `[${PLUGIN_NAME}] No queries provided, nothing has been indexed to MeiliSearch`
+        getErrorMsg(
+          'No queries provided, nothing has been indexed to MeiliSearch'
+        )
       )
       return
     }
     validatePluginOptions(queries, host)
+
+    // Get graphQL data
     const { data } = await graphql(queries.query)
-    console.log(data)
+
+    const client = new MeiliSearch({
+      host: host,
+      apiKey: apiKey,
+    })
+
+    // Prepare data for indexation
+    const transformedData = await queries.transformer(data)
+
+    // Create index
+    const index = await client.getOrCreateIndex(queries.indexUid)
+
+    // Index data to MeiliSearch
+    const { updateId } = await index.addDocuments(transformedData)
+
+    // Check status
+    await index.waitForPendingUpdate(updateId)
+    const res = await index.getUpdateStatus(updateId)
+    if (res.status === 'failed') {
+      throw getErrorMsg(res.message)
+    }
+
+    activity.setStatus('Documents added to MeiliSearch')
   } catch (err) {
-    reporter.error(err)
+    reporter.error(err.message || err)
     activity.setStatus('Failed to index to MeiliSearch')
   }
   activity.end()

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "eslint-plugin-react": "^7.24.0",
     "prettier": "^2.3.2",
     "react": "^17.0.2"
+  },
+  "dependencies": {
+    "meilisearch": "^0.19.0"
   }
 }

--- a/playground/gatsby-config.js
+++ b/playground/gatsby-config.js
@@ -69,6 +69,3 @@ module.exports = {
     },
   ],
 }
-
-// transformer : obligatoire
-// Si pas de `id` -> reporter.error

--- a/playground/gatsby-config.js
+++ b/playground/gatsby-config.js
@@ -1,3 +1,5 @@
+require('dotenv').config()
+
 module.exports = {
   siteMetadata: {
     siteUrl: 'https://www.yourdomain.tld',
@@ -38,18 +40,23 @@ module.exports = {
     {
       resolve: require.resolve(`../`),
       options: {
-        host: 'http://127.0.0.1:7700',
-        apiKey: 'masterKey',
-        skipIndexing: true,
+        host:
+          process.env.GATSBY_MEILI_SERVER_ADDRESS || 'http://localhost:7700',
+        apiKey: process.env.GATSBY_MEILI_API_KEY || 'masterKey',
+        // skipIndexing: true,
         queries: {
-          indexUid: 'MyBlog',
+          indexUid: process.env.GATSBY_MEILI_INDEX_NAME || 'my_blog',
+          transformer: data => data.allMdx.edges.map(({ node }) => node),
           query: `
             query MyQuery {
               allMdx {
                 edges {
                   node {
+                    id
+                    slug
                     frontmatter {
                       title
+                      cover
                     }
                     tableOfContents
                   }
@@ -62,3 +69,6 @@ module.exports = {
     },
   ],
 }
+
+// transformer : obligatoire
+// Si pas de `id` -> reporter.error

--- a/playground/gatsby-config.js
+++ b/playground/gatsby-config.js
@@ -40,9 +40,8 @@ module.exports = {
     {
       resolve: require.resolve(`../`),
       options: {
-        host:
-          process.env.GATSBY_MEILI_SERVER_ADDRESS || 'http://localhost:7700',
-        apiKey: process.env.GATSBY_MEILI_API_KEY || 'masterKey',
+        host: process.env.GATSBY_MEILI_HTTP_ADDR || 'http://localhost:7700',
+        apiKey: process.env.GATSBY_MEILI_MASTER_KEY || 'masterKey',
         // skipIndexing: true,
         queries: {
           indexUid: process.env.GATSBY_MEILI_INDEX_NAME || 'my_blog',

--- a/playground/package.json
+++ b/playground/package.json
@@ -22,7 +22,7 @@
         "../gatsby-node.js",
         "../package.json",
         "./src",
-        "./gatsby-config",
+        "./gatsby-config.js",
         "./package.json"
       ],
       "quiet": true
@@ -38,6 +38,7 @@
     "gatsby-plugin-sharp": "^3.8.0",
     "gatsby-remark-images": "^5.5.0",
     "gatsby-source-filesystem": "^3.8.0",
+    "instantsearch.css": "^7.4.5",
     "kill-port": "^1.6.1",
     "npm-watch": "^0.10.0",
     "react": "^17.0.1",

--- a/playground/src/pages/index.js
+++ b/playground/src/pages/index.js
@@ -1,64 +1,46 @@
 import React from 'react'
-import { graphql } from 'gatsby'
-import {
-  InstantSearch,
-  Hits,
-  SearchBox,
-  Pagination,
-  Highlight,
-} from 'react-instantsearch-dom'
+import { InstantSearch, Hits, SearchBox } from 'react-instantsearch-dom'
+import { Link } from 'gatsby'
+import 'instantsearch.css/themes/algolia-min.css'
 import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
 
-const searchClient = instantMeiliSearch('http://localhost:7700', 'masterKey')
+const SERVER_ADDRESS =
+  process.env.GATSBY_MEILI_SERVER_ADDRESS || 'http://localhost:7700'
+const API_KEY = process.env.GATSBY_MEILI_API_KEY || 'masterKey'
+const INDEX_NAME = process.env.GATSBY_MEILI_INDEX_NAME || 'my_blog'
 
-const App = ({ data }) => (
+const searchClient = instantMeiliSearch(SERVER_ADDRESS, API_KEY, {
+  primaryKey: 'id',
+})
+
+const App = () => (
   <div className="ais-InstantSearch">
     <h1>MeiliSearch + React InstantSearch + Gatsby</h1>
-
-    <p>Article List: </p>
-    <ul className="article-list">
-      {data?.allMdx?.edges?.map(({ node }, index) => (
-        <li key={index}>
-          <a href={node.slug}>{node.frontmatter.title}</a>
-        </li>
-      ))}
-    </ul>
     <h2>Search in this blog’s articles </h2>
-    <InstantSearch indexName="animals" searchClient={searchClient}>
-      <div className="right-panel">
+    <InstantSearch indexName={INDEX_NAME} searchClient={searchClient}>
+      <div style={{ marginBottom: 16 }}>
         <SearchBox />
-        <Hits hitComponent={Hit} />
-        <Pagination showLast={true} />
       </div>
+      <Hits hitComponent={Hit} />
     </InstantSearch>
   </div>
 )
 
-function Hit(props) {
-  return (
-    <div key={props.hit.id}>
-      <div className="hit-title">
-        <Highlight attribute="title" hit={props.hit} />
-      </div>
-      <img src={props.hit.image} align="left" alt={props.hit.title} />
-    </div>
-  )
-}
-
-export const query = graphql`
-  query HomePageQuery {
-    allMdx(sort: { fields: frontmatter___title, order: ASC }) {
-      edges {
-        node {
-          slug
-          frontmatter {
-            title
-            cover
-          }
-        }
-      }
-    }
-  }
-`
+const Hit = ({ hit }) => (
+  <div
+    key={hit.id}
+    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
+  >
+    <h3 className="hit-title" style={{ marginTop: 0 }}>
+      {hit.frontmatter.title}
+    </h3>
+    <img
+      src={hit.frontmatter.cover}
+      alt={hit.frontmatter.title}
+      style={{ maxWidth: '100%' }}
+    />
+    <Link to={`/${hit.slug}`}>See page</Link>
+  </div>
+)
 
 export default App

--- a/playground/src/pages/index.js
+++ b/playground/src/pages/index.js
@@ -5,8 +5,8 @@ import 'instantsearch.css/themes/algolia-min.css'
 import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
 
 const SERVER_ADDRESS =
-  process.env.GATSBY_MEILI_SERVER_ADDRESS || 'http://localhost:7700'
-const API_KEY = process.env.GATSBY_MEILI_API_KEY || 'masterKey'
+  process.env.GATSBY_MEILI_HTTP_ADDR || 'http://localhost:7700'
+const API_KEY = process.env.GATSBY_MEILI_MASTER_KEY || 'masterKey'
 const INDEX_NAME = process.env.GATSBY_MEILI_INDEX_NAME || 'my_blog'
 
 const searchClient = instantMeiliSearch(SERVER_ADDRESS, API_KEY, {

--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -7346,6 +7346,11 @@ inquirer@^7.0.0:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
+instantsearch.css@^7.4.5:
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.4.5.tgz#2a521aa634329bf1680f79adf87c79d67669ec8d"
+  integrity sha512-iIGBYjCokU93DDB8kbeztKtlu4qVEyTg1xvS6iSO1YvqRwkIZgf0tmsl/GytsLdZhuw8j4wEaeYsCzNbeJ/zEQ==
+
 internal-ip@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-4.3.0.tgz#845452baad9d2ca3b69c635a137acb9a0dad0907"

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,6 +469,13 @@ core-util-is@1.0.2:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cross-fetch@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
+  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
+  dependencies:
+    node-fetch "2.6.1"
+
 cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -1440,6 +1447,13 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+meilisearch@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.19.0.tgz#b94b97b30a4e62270e53860c3a6b2e25765b00f3"
+  integrity sha512-o1rKT65q09i0W/vigpGEXVTX44A8IBscNQhZ+JkAlEgpk2+mYZMQxHXcoBtWjZI/CYKoswVnUxBVB4HEJ8tJQw==
+  dependencies:
+    cross-fetch "^3.1.4"
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -1488,6 +1502,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+node-fetch@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 normalize-package-data@^2.5.0:
   version "2.5.0"


### PR DESCRIPTION
Closes #7 

## What's inside this PR ? 

- Addition of a `transformer` function inside the plugin options, to transform the data to the correct format before indexing it
- Indexing of the data & error log if it occurs
- Update of the front-end to retrieve & display the indexed data
- Removal of the test testing the article list, as the playground homepage has changed, and this point is going to be done in #8 
- Documentation update (`CONTRIBUTING.md` and `README.md`)

## How to test ?

You can test with a MeiliSearch running in local, or by providing a `.env` file inside the `playground` folder with the following environment variable : 

```bash
GATSBY_MEILI_SERVER_ADDRESS
GATSBY_MEILI_API_KEY
GATSBY_MEILI_INDEX_NAME
```

Then, run:
 
```bash
yarn playground:build // Generate a single build
or: 
yarn playground:dev // Generate a build with watch mode
```

## Screenshots

<img width="934" alt="Capture d’écran 2021-07-26 à 11 10 55" src="https://user-images.githubusercontent.com/30866152/126965437-ffb38289-74ad-4965-b96e-8fc2ecc396ff.png">
