### PR TITLE
Remove the default "## Changes" section

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -17,8 +17,6 @@ categories:
   - title: '🔒 Security'
     label: 'security'
 template: |
-  ## Changes
-
   $CHANGES
 
   Thanks again to $CONTRIBUTORS! 🎉


### PR DESCRIPTION
This PR is to remove the default "Changes" section in the release so that we enforce the maintainer to put every PR in a dedicated section.
Also, this should ensure the "breaking changes" section is at the top of the release (following https://github.com/meilisearch/integration-guides/issues/148)