### PR TITLE
Add skipindexing option

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,7 +10,20 @@ exports.onPostBuild = async function ({ graphql, reporter }, config) {
   const activity = reporter.activityTimer(PLUGIN_NAME)
   activity.start()
   try {
-    const { queries, host, apiKey = '', batchSize = 1000 } = config
+    const {
+      queries,
+      host,
+      apiKey = '',
+      batchSize = 1000,
+      skipIndexing = false,
+    } = config
+
+    if (skipIndexing) {
+      activity.setStatus('Indexation skipped')
+      activity.end()
+      return
+    }
+
     if (!queries) {
       reporter.warn(
         getErrorMsg(

--- a/playground/gatsby-config.js
+++ b/playground/gatsby-config.js
@@ -46,7 +46,12 @@ module.exports = {
         batchSize: 1,
         queries: {
           indexUid: process.env.GATSBY_MEILI_INDEX_NAME || 'my_blog',
-          transformer: data => data.allMdx.edges.map(({ node }) => node),
+          transformer: data =>
+            data.allMdx.edges.map(({ node }) => ({
+              ...node,
+              title: node.frontmatter.title,
+              cover: node.frontmatter.cover,
+            })),
           query: `
             query MyQuery {
               allMdx {

--- a/tests/index-to-meilisearch.test.js
+++ b/tests/index-to-meilisearch.test.js
@@ -118,6 +118,16 @@ describe('Index to MeiliSearch', () => {
       'Failed to index to MeiliSearch'
     )
   })
+
+  test('Skip indexing', async () => {
+    await onPostBuild(
+      { graphql: fakeGraphql, reporter: fakeReporter },
+      { ...fakeConfig, skipIndexing: true }
+    )
+    expect(activity.setStatus).toHaveBeenCalledTimes(1)
+    expect(activity.setStatus).toHaveBeenCalledWith('Indexation skipped')
+  })
+
   test('Indexation succeeded', async () => {
     await onPostBuild(
       { graphql: fakeGraphql, reporter: fakeReporter },


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Closes #12

- Addition of a new option to skip the indexation
- Addition of a test to test this new option
- Update of the transformer in the playground, in order for the documents to display better in the mini-dashboard

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

## How to test

- Run the tests with `yarn test` and `yarn test:e2e`
- You can also run MeiliSearch locally, go to `playground/gatsby-config.js` and add `skipIndexing: true` (it should already be there and commented). Then simply run `playground:build` and you should see in the build messages that the indexation has been skipped (see screenshot below). You can also open the mini-dashboard in order to check that no documents are present

## Screenshots

With `skipIndexing` set to `true`: 

<img width="478" alt="Capture d’écran 2021-12-02 à 17 09 52" src="https://user-images.githubusercontent.com/30866152/144459872-10164253-9b1c-4cee-9d2f-f60507d18121.png">

