### PR TITLE
Add meilisearch settings to plugin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ docker run -it --rm -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --mas
 
 ### Basic
 
-
 `gatsby-config.js`
 
 ```node
@@ -112,14 +111,17 @@ docker run -it --rm -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --mas
 ### Customization
 
 The plugin accepts the following options for further customization :
+
 ```node
 {
   resolve: 'gatsby-plugin-meilisearch',
   options: {
-    // API key if the MeiliSearch instance is password protected
-    apiKey: "masterKey",
+    apiKey: "masterKey", // API key if the MeiliSearch instance is password protected
     skipIndexing: true, // Run script without indexing to MeiliSearch. Default to false
     batchSize: 1000, // The number of documents that should be included in each batch. Default to 1000
+    settings: {
+      searchableAttributes: ['title'], // MeiliSearch's settings. See https://docs.meilisearch.com/reference/features/settings.html
+    },
   },
 }
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -42,10 +42,16 @@ exports.onPostBuild = async function ({ graphql, reporter }, config) {
       apiKey: apiKey,
     })
 
+    const index = client.index(queries.indexUid)
+
+    // Add settings to Index
+    if (queries.settings) {
+      const { updateId } = await index.updateSettings(queries.settings)
+      index.waitForPendingUpdate(updateId)
+    }
+
     // Prepare data for indexation
     const transformedData = await queries.transformer(data)
-
-    const index = client.index(queries.indexUid)
 
     // Index data to MeiliSearch
     const enqueuedUpdates = await index.addDocumentsInBatches(

--- a/playground/gatsby-config.js
+++ b/playground/gatsby-config.js
@@ -46,6 +46,9 @@ module.exports = {
         batchSize: 1,
         queries: {
           indexUid: process.env.GATSBY_MEILI_INDEX_NAME || 'my_blog',
+          settings: {
+            searchableAttributes: ['title'],
+          },
           transformer: data =>
             data.allMdx.edges.map(({ node }) => ({
               ...node,

--- a/playground/src/pages/index.js
+++ b/playground/src/pages/index.js
@@ -31,15 +31,15 @@ const Hit = ({ hit }) => (
     key={hit.id}
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
   >
-    <h3 className="hit-title" style={{ marginTop: 0 }}>
-      {hit.frontmatter.title}
-    </h3>
-    <img
-      src={hit.frontmatter.cover}
-      alt={hit.frontmatter.title}
-      style={{ maxWidth: '100%' }}
-    />
-    <Link to={`/${hit.slug}`}>See page</Link>
+    {hit.title && (
+      <h3 className="hit-title" style={{ marginTop: 0 }}>
+        {hit.title}
+      </h3>
+    )}
+    {hit.cover && (
+      <img src={hit.cover} alt={hit.title || ''} style={{ maxWidth: '100%' }} />
+    )}
+    <Link to={`/${hit.slug || ''}`}>See page</Link>
   </div>
 )
 


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Closes #14

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

## What's inside this PR ? 
- Addition of a new option `settings`, allowing the user to update its MeiliSearch settings
- Update of the Readme with the new settings option
- Addition of a settings example inside the Playground
- Add extraneous checks to avoid crashes in the playground front-end
- Addition of new tests (wrong settings + good settings provided to MeiliSearch)

## How to test ? 
- `yarn test`
- `yarn playground:dev` and edit the `settings` option inside `playground/gatsby-config.js` to see that the changes are applied

