### PR TITLE
Allow multi indexing

### DIFF
--- a/playground/gatsby-config.js
+++ b/playground/gatsby-config.js
@@ -44,35 +44,37 @@ module.exports = {
         apiKey: process.env.GATSBY_MEILI_MASTER_KEY || 'masterKey',
         // skipIndexing: true,
         batchSize: 1,
-        queries: {
-          indexUid: process.env.GATSBY_MEILI_INDEX_NAME || 'my_blog',
-          settings: {
-            searchableAttributes: ['title'],
-          },
-          transformer: data =>
-            data.allMdx.edges.map(({ node }) => ({
-              ...node,
-              title: node.frontmatter.title,
-              cover: node.frontmatter.cover,
-            })),
-          query: `
-            query MyQuery {
-              allMdx {
-                edges {
-                  node {
-                    id
-                    slug
-                    frontmatter {
-                      title
-                      cover
+        indexes: [
+          {
+            indexUid: process.env.GATSBY_MEILI_INDEX_NAME || 'my_blog',
+            settings: {
+              searchableAttributes: ['title'],
+            },
+            transformer: data =>
+              data.allMdx.edges.map(({ node }) => ({
+                ...node,
+                title: node.frontmatter.title,
+                cover: node.frontmatter.cover,
+              })),
+            query: `
+              query MyQuery {
+                allMdx {
+                  edges {
+                    node {
+                      id
+                      slug
+                      frontmatter {
+                        title
+                        cover
+                      }
+                      tableOfContents
                     }
-                    tableOfContents
                   }
                 }
               }
-            }
-          `,
-        },
+            `,
+          },
+        ],
       },
     },
   ],

--- a/src/validate.js
+++ b/src/validate.js
@@ -30,12 +30,8 @@ const validatePluginOptions = (indexes, host) => {
     throw getValidationError('"host"')
   }
 
-  if (!indexes || indexes.length === 0) {
-    throw getErrorMsg('The "indexes" option must not be empty')
-  }
-
   if (!Array.isArray(indexes)) {
-    throw getErrorMsg('The "indexes" option must be an array')
+    throw getErrorMsg('The "indexes" option should be of type array')
   }
 }
 

--- a/src/validate.js
+++ b/src/validate.js
@@ -8,28 +8,40 @@ const isObject = obj =>
 const getValidationError = field =>
   `[${PLUGIN_NAME}] The field ${field} is required in the plugin configuration`
 
-const validatePluginOptions = (queries, host) => {
+const validateIndexOptions = (index, key) => {
+  if (!isObject(index)) {
+    throw getErrorMsg(
+      `Each index inside the "indexes" field must be of type object and contain the following fields: "indexUid", "query", "transformer" (in "indexes" at position ${key})`
+    )
+  }
+  if (!index.indexUid) {
+    throw getValidationError(`"indexUid" (in "indexes" at position ${key})`)
+  }
+  if (!index.query) {
+    throw getValidationError(`"query" (in "indexes" at position ${key})`)
+  }
+  if (!index.transformer) {
+    throw getValidationError(`"transformer" (in "indexes" at position ${key})`)
+  }
+}
+
+const validatePluginOptions = (indexes, host) => {
   if (!host) {
     throw getValidationError('"host"')
   }
-  if (!isObject(queries)) {
-    throw getErrorMsg(
-      'The field "queries" must be of type object and contain the following fields: "indexUid", "query", "transformer"'
-    )
+
+  if (!indexes || indexes.length === 0) {
+    throw getErrorMsg('The "indexes" option must not be empty')
   }
-  if (!queries.indexUid) {
-    throw getValidationError('"indexUid" in the "queries" object')
-  }
-  if (!queries.query) {
-    throw getValidationError('"query" in the "queries" object')
-  }
-  if (!queries.transformer) {
-    throw getValidationError('"transformer" in the "queries" object')
+
+  if (!Array.isArray(indexes)) {
+    throw getErrorMsg('The "indexes" option must be an array')
   }
 }
 
 module.exports = {
   validatePluginOptions,
+  validateIndexOptions,
   getValidationError,
   getErrorMsg,
   PLUGIN_NAME,

--- a/tests/index-to-meilisearch.test.js
+++ b/tests/index-to-meilisearch.test.js
@@ -34,7 +34,7 @@ describe('Index to MeiliSearch', () => {
     )
   })
 
-  test('Should fail on Wrong graphQL query', async () => {
+  test('Should fail on wrong graphQL query', async () => {
     const wrongQuery = `
     query MyQuery {
       allMdx {

--- a/tests/index-to-meilisearch.test.js
+++ b/tests/index-to-meilisearch.test.js
@@ -13,23 +13,28 @@ const client = new MeiliSearch({
 describe('Index to MeiliSearch', () => {
   beforeEach(async () => {
     try {
-      await client.deleteIndex(fakeConfig.queries.indexUid)
+      await Promise.all(
+        fakeConfig.indexes.map(
+          async index => await client.deleteIndex(index.indexUid)
+        )
+      )
     } catch (e) {
       return
     }
   })
-  test('Has no queries', async () => {
+
+  test('Should fail if the indexes field is not provided', async () => {
     await onPostBuild(
       { graphql: fakeGraphql, reporter: fakeReporter },
-      { ...fakeConfig, queries: null }
+      { ...fakeConfig, indexes: null }
     )
     expect(fakeReporter.warn).toHaveBeenCalledTimes(1)
     expect(fakeReporter.warn).toHaveBeenCalledWith(
-      `[gatsby-plugin-meilisearch] No queries provided, nothing has been indexed to MeiliSearch`
+      `[gatsby-plugin-meilisearch] No indexes provided, nothing has been indexed to MeiliSearch`
     )
   })
 
-  test('Wrong graphQL query', async () => {
+  test('Should fail on Wrong graphQL query', async () => {
     const wrongQuery = `
     query MyQuery {
       allMdx {
@@ -37,9 +42,13 @@ describe('Index to MeiliSearch', () => {
       }
     }
   `
+
     await onPostBuild(
       { graphql: fakeGraphql, reporter: fakeReporter },
-      { ...fakeConfig, queries: { ...fakeConfig.queries, query: wrongQuery } }
+      {
+        ...fakeConfig,
+        indexes: [{ ...fakeConfig.indexes[0], query: wrongQuery }],
+      }
     )
     expect(fakeReporter.error).toHaveBeenCalledTimes(1)
     expect(fakeReporter.error).toHaveBeenCalledWith(
@@ -51,14 +60,14 @@ describe('Index to MeiliSearch', () => {
     )
   })
 
-  test('Wrong transformer', async () => {
+  test('Should fail on wrong transformer format', async () => {
     const wrongTransformer = data => data.allMdx.map(({ node }) => node)
 
     await onPostBuild(
       { graphql: fakeGraphql, reporter: fakeReporter },
       {
         ...fakeConfig,
-        queries: { ...fakeConfig.queries, transformer: wrongTransformer },
+        indexes: [{ ...fakeConfig.indexes[0], transformer: wrongTransformer }],
       }
     )
     expect(fakeReporter.error).toHaveBeenCalledTimes(1)
@@ -71,14 +80,14 @@ describe('Index to MeiliSearch', () => {
     )
   })
 
-  test('Wrong document format sent to MeiliSearch', async () => {
+  test('Should fail on wrong document format sent to MeiliSearch', async () => {
     const wrongTransformer = data => data
 
     await onPostBuild(
       { graphql: fakeGraphql, reporter: fakeReporter },
       {
         ...fakeConfig,
-        queries: { ...fakeConfig.queries, transformer: wrongTransformer },
+        indexes: [{ ...fakeConfig.indexes[0], transformer: wrongTransformer }],
       }
     )
     expect(fakeReporter.error).toHaveBeenCalledTimes(1)
@@ -91,7 +100,7 @@ describe('Index to MeiliSearch', () => {
     )
   })
 
-  test('Document has no id', async () => {
+  test('Should fail if there are no primary key in the documents', async () => {
     const wrongQuery = `
     query MyQuery {
       allMdx {
@@ -106,7 +115,7 @@ describe('Index to MeiliSearch', () => {
       { graphql: fakeGraphql, reporter: fakeReporter },
       {
         ...fakeConfig,
-        queries: { ...fakeConfig.queries, query: wrongQuery },
+        indexes: [{ ...fakeConfig.indexes[0], query: wrongQuery }],
       }
     )
     expect(fakeReporter.error).toHaveBeenCalledTimes(1)
@@ -119,15 +128,17 @@ describe('Index to MeiliSearch', () => {
     )
   })
 
-  test('Wrong settings format', async () => {
+  test('Should fail on wrong settings format', async () => {
     await onPostBuild(
       { graphql: fakeGraphql, reporter: fakeReporter },
       {
         ...fakeConfig,
-        queries: {
-          ...fakeConfig.queries,
-          settings: { wrongSettings: 'wrongSettings' },
-        },
+        indexes: [
+          {
+            ...fakeConfig.indexes[0],
+            settings: { wrongSettings: 'wrongSettings' },
+          },
+        ],
       }
     )
     expect(fakeReporter.error).toHaveBeenCalledTimes(1)
@@ -140,26 +151,27 @@ describe('Index to MeiliSearch', () => {
     )
   })
 
-  test('Good settings format', async () => {
+  test('Should succeed on good settings format', async () => {
     await onPostBuild(
       { graphql: fakeGraphql, reporter: fakeReporter },
       {
         ...fakeConfig,
-        queries: {
-          ...fakeConfig.queries,
-          settings: { searchableAttributes: ['title'] },
-        },
+        indexes: [
+          {
+            ...fakeConfig.indexes[0],
+            settings: { searchableAttributes: ['title'] },
+          },
+        ],
       }
     )
     const { searchableAttributes } = await client
-      .index(fakeConfig.queries.indexUid)
+      .index(fakeConfig.indexes[0].indexUid)
       .getSettings()
-    console.log(searchableAttributes)
     expect(Array.isArray(searchableAttributes)).toBe(true)
     expect(searchableAttributes).toEqual(['title'])
   })
 
-  test('Skip indexing', async () => {
+  test('Should skip the indexation', async () => {
     await onPostBuild(
       { graphql: fakeGraphql, reporter: fakeReporter },
       { ...fakeConfig, skipIndexing: true }
@@ -168,7 +180,36 @@ describe('Index to MeiliSearch', () => {
     expect(activity.setStatus).toHaveBeenCalledWith('Indexation skipped')
   })
 
-  test('Indexation succeeded', async () => {
+  test('Should succeed on multi indexing', async () => {
+    await onPostBuild(
+      { graphql: fakeGraphql, reporter: fakeReporter },
+      {
+        ...fakeConfig,
+        indexes: [
+          ...fakeConfig.indexes,
+          {
+            indexUid: 'index2',
+            transformer: data => data.allMdx.edges.map(({ node }) => node),
+            query: `
+                query MyQuery {
+                  allMdx {
+                    edges {
+                      node {
+                        id
+                      }
+                    }
+                  }
+                }
+              `,
+          },
+        ],
+      }
+    )
+    const indexes = await client.getIndexes()
+    expect(indexes).toHaveLength(2)
+  })
+
+  test('Should succeed and index with good config format', async () => {
     await onPostBuild(
       { graphql: fakeGraphql, reporter: fakeReporter },
       fakeConfig

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -3,28 +3,29 @@
 const fakeConfig = {
   host: process.env.MEILI_HTTP_ADDR || 'http://localhost:7700',
   apiKey: process.env.MEILI_MASTER_KEY || 'masterKey',
-  // skipIndexing: true,
-  queries: {
-    indexUid: process.env.MEILI_INDEX_NAME || 'my_blog',
-    transformer: data => data.allMdx.edges.map(({ node }) => node),
-    query: `
-      query MyQuery {
-        allMdx {
-          edges {
-            node {
-              id
-              slug
-              frontmatter {
-                title
-                cover
+  indexes: [
+    {
+      indexUid: process.env.MEILI_INDEX_NAME || 'my_blog',
+      transformer: data => data.allMdx.edges.map(({ node }) => node),
+      query: `
+        query MyQuery {
+          allMdx {
+            edges {
+              node {
+                id
+                slug
+                frontmatter {
+                  title
+                  cover
+                }
+                tableOfContents
               }
-              tableOfContents
             }
           }
         }
-      }
-    `,
-  },
+      `,
+    },
+  ],
 }
 
 const fakeGraphql = async query => {

--- a/tests/validate-options.test.js
+++ b/tests/validate-options.test.js
@@ -1,6 +1,10 @@
 /* eslint-disable no-undef */
 const { fakeConfig } = require('./utils')
-const { validatePluginOptions, getValidationError } = require('../src/validate')
+const {
+  validatePluginOptions,
+  validateIndexOptions,
+  getValidationError,
+} = require('../src/validate')
 
 const fakeGetValidationError = jest.fn(getValidationError)
 
@@ -9,7 +13,7 @@ const validateError = param => {
 }
 
 describe('validate options', () => {
-  test('Has no host', async () => {
+  test('Should fail with no "host" field', async () => {
     const validate = () => {
       validatePluginOptions(fakeConfig.queries, null)
     }
@@ -17,7 +21,7 @@ describe('validate options', () => {
       `[gatsby-plugin-meilisearch] The field "host" is required in the plugin configuration`
     )
   })
-  test('Calls getValidationError function', async () => {
+  test('Should call "getValidationError" function', async () => {
     const validate = () => {
       validatePluginOptions(fakeConfig.queries, null)
     }
@@ -30,50 +34,60 @@ describe('validate options', () => {
     )
   })
 
-  test("Queries isn't an object", async () => {
+  test('Should fail if "indexes" field is empty', async () => {
     const validate = () => {
-      validatePluginOptions([], fakeConfig.host)
+      validatePluginOptions(null, fakeConfig.host)
     }
     expect(() => validate()).toThrow(
-      `[gatsby-plugin-meilisearch] The field "queries" must be of type object and contain the following fields: "indexUid", "query", "transformer"`
+      `[gatsby-plugin-meilisearch] The "indexes" option must not be empty`
     )
   })
-  test('Has no indexUid', async () => {
+
+  test('Should fail if "indexes" field isn’t an array', async () => {
     const validate = () => {
-      validatePluginOptions(
-        { ...fakeConfig.queries, indexUid: null },
-        fakeConfig.host
-      )
+      validatePluginOptions({}, fakeConfig.host)
     }
     expect(() => validate()).toThrow(
-      `[gatsby-plugin-meilisearch] The field "indexUid" in the "queries" object is required in the plugin configuration`
+      `[gatsby-plugin-meilisearch] The "indexes" option must be an array`
     )
   })
-  test('Has no query', async () => {
+
+  test('Should fail "index" field isn’t an object', async () => {
     const validate = () => {
-      validatePluginOptions(
-        { ...fakeConfig.queries, query: null },
-        fakeConfig.host
-      )
+      validateIndexOptions([], 0)
     }
     expect(() => validate()).toThrow(
-      `[gatsby-plugin-meilisearch] The field "query" in the "queries" object is required in the plugin configuration`
+      `[gatsby-plugin-meilisearch] Each index inside the "indexes" field must be of type object and contain the following fields: "indexUid", "query", "transformer" (in "indexes" at position 0)`
     )
   })
-  test('Has no transformer', async () => {
+
+  test('Should fail if "index" field has no indexUid', async () => {
     const validate = () => {
-      validatePluginOptions(
-        { ...fakeConfig.queries, transformer: null },
-        fakeConfig.host
-      )
+      validateIndexOptions({ ...fakeConfig.indexes[0], indexUid: null }, 0)
     }
     expect(() => validate()).toThrow(
-      `[gatsby-plugin-meilisearch] The field "transformer" in the "queries" object is required in the plugin configuration`
+      `[gatsby-plugin-meilisearch] The field "indexUid" (in "indexes" at position 0) is required in the plugin configuration`
     )
   })
-  test('Has valid options', async () => {
+  test('Should fail if "index" field has no query', async () => {
     const validate = () => {
-      validatePluginOptions(fakeConfig.queries, fakeConfig.host)
+      validateIndexOptions({ ...fakeConfig.indexes[0], query: null }, 0)
+    }
+    expect(() => validate()).toThrow(
+      `[gatsby-plugin-meilisearch] The field "query" (in "indexes" at position 0) is required in the plugin configuration`
+    )
+  })
+  test('Should fail if "index" field has no transformer', async () => {
+    const validate = () => {
+      validateIndexOptions({ ...fakeConfig.indexes[0], transformer: null }, 0)
+    }
+    expect(() => validate()).toThrow(
+      `[gatsby-plugin-meilisearch] The field "transformer" (in "indexes" at position 0) is required in the plugin configuration`
+    )
+  })
+  test('Should succeed if "index" field has valid options', async () => {
+    const validate = () => {
+      validatePluginOptions(fakeConfig.indexes, fakeConfig.host)
     }
     expect(() => validate()).not.toThrow()
   })

--- a/tests/validate-options.test.js
+++ b/tests/validate-options.test.js
@@ -34,21 +34,12 @@ describe('validate options', () => {
     )
   })
 
-  test('Should fail if "indexes" field is empty', async () => {
-    const validate = () => {
-      validatePluginOptions(null, fakeConfig.host)
-    }
-    expect(() => validate()).toThrow(
-      `[gatsby-plugin-meilisearch] The "indexes" option must not be empty`
-    )
-  })
-
   test('Should fail if "indexes" field isn’t an array', async () => {
     const validate = () => {
       validatePluginOptions({}, fakeConfig.host)
     }
     expect(() => validate()).toThrow(
-      `[gatsby-plugin-meilisearch] The "indexes" option must be an array`
+      `[gatsby-plugin-meilisearch] The "indexes" option should be of type array`
     )
   })
 


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Closes #15

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

## What's inside this PR ? 
- Renaming of the field `queries` into `indexes`
- The `indexes` field is now an array and allows us to provide multiple indexes and queries for indexation
- Separation of the `validatePluginOptions` in 2 functions : `validatePluginOptions` for the global plugin options, and `validateIndexOptions` for the validation of each indexes options
- Update of the playground plugin config to pass the `indexes` as an array
- Update of each tests name for better understanding of what it should do
- Update of the tests with the new naming (`indexes`) + addition of a new test testing the multi-indexation

## How to test ? 
- `yarn test`
- `yarn playground:dev` and update the `playground/gatsby-config.js` by adding a second index (see example below). By going to your MeiliSearch's mini-dashboard (http://127.0.0.1:7700/ for me), you should see that the 2 indexes were created. You can also edit the `INDEX_NAME` inside `playground/src/pages/index.js` and see the changes on http://localhost:9000/

Example of second index : 
```js
 {
            indexUid: 'index2',
            transformer: data => data.allMdx.edges.map(({ node }) => node),
            query: `
              query MyQuery {
                allMdx {
                  edges {
                    node {
                      id
                    }
                  }
                }
              }
            `,
          },
```