### PR TITLE
Pass gatsby client agent to meilisearch-js

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,5 +1,5 @@
 const { MeiliSearch } = require('meilisearch')
-
+const { constructClientAgents } = require('./src/agents')
 const {
   validatePluginOptions,
   validateIndexOptions,
@@ -27,6 +27,7 @@ exports.onPostBuild = async function ({ graphql, reporter }, config) {
       skipIndexing = false,
       batchSize = 1000,
       indexes,
+      clientAgents = [],
     } = config
 
     if (skipIndexing) {
@@ -59,6 +60,7 @@ exports.onPostBuild = async function ({ graphql, reporter }, config) {
         const client = new MeiliSearch({
           host: host,
           apiKey: apiKey,
+          clientAgents: constructClientAgents(clientAgents),
         })
 
         const index = client.index(currentIndex.indexUid)

--- a/src/agents.js
+++ b/src/agents.js
@@ -1,0 +1,11 @@
+const { version } = require('../package.json')
+
+const constructClientAgents = (clientAgents = []) => {
+  const instantMeilisearchAgent = `Meilisearch Gatsby (v${version})`
+
+  return clientAgents.concat(instantMeilisearchAgent)
+}
+
+module.exports = {
+  constructClientAgents,
+}


### PR DESCRIPTION
See [related issue](https://github.com/meilisearch/integration-guides/issues/150)

This PR passes down the information of the gatsby plugin package to the meilisearch-js package which in turn provided the information to meilisearch.