### PR TITLE
Update version for the next release (v0.2.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-meilisearch",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Gatsby plugin to index your content to Meilisearch based on queries",
   "main": "gatsby-node.js",
   "scripts": {


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.29.0 :tada:
Check out the changelog of [Meilisearch v0.29.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.29.0) for more information on the changes.
