### PR TITLE
revert actions config - issue can no longer be reproduced

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,16 +48,8 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn
-      - name: Install playground dependencies
-        run: yarn --cwd ./playground
-      - name: Build playground
-        run: yarn playground:build
-      - name: Start playground
-        run: yarn playground:start &
-      - name: Sleep
-        run: sleep 30
       - name: Run tests
-        run: yarn ci:test
+        run: yarn test
         env:
           MEILI_HTTP_ADDR: 'http://localhost:7700'
           MEILI_MASTER_KEY: masterKey

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "playground:build": "yarn --cwd ./playground build",
     "playground:dev": "yarn --cwd ./playground && yarn --cwd ./playground watch",
     "playground:serve": "yarn --cwd ./playground serve",
-    "ci:test": "jest --testPathPattern=tests --verbose --detectOpenHandles",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
     "test:e2e": "yarn playground:build && concurrently --kill-others -s first \"yarn --cwd ./playground serve\" \"cypress run\"",


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #159 

## What does this PR do?
- Reverts workaround in tests.yml (sleep 30)

I cannot reproduce the original issue anymore. [Successful CI run](https://github.com/dadolhay/gatsby-plugin-meilisearch/actions/runs/3220634401)

Thank you so much for contributing to Meilisearch!
