### PR TITLE
Make document addition asynchronous and improve report on it

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -75,7 +75,7 @@ exports.onPostBuild = async function ({ graphql, reporter }, config) {
 
         const tasks = []
 
-        // Send documents in batches of `batchSize`
+        // Creating document batches of `batchSize` and adding them to Meilisearch
         for (let i = 0; i < transformedData.length; i += batchSize) {
           let documentsActivity = reporter.activityTimer(
             'Send documents to Meilisearch'

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -25,7 +25,7 @@ exports.onPostBuild = async function ({ graphql, reporter }, config) {
       host,
       apiKey = '',
       skipIndexing = false,
-      batchSize = 1000,
+      batchSize = 10000,
       indexes,
       clientAgents = [],
     } = config
@@ -63,45 +63,50 @@ exports.onPostBuild = async function ({ graphql, reporter }, config) {
           clientAgents: constructClientAgents(clientAgents),
         })
 
-        const index = client.index(currentIndex.indexUid)
+        const index = await client.index(currentIndex.indexUid)
         await index.delete()
-
         // Add settings to Index
         if (currentIndex.settings) {
-          const { taskUid: settingsUid } = await index.updateSettings(
-            currentIndex.settings
-          )
-          index.waitForTask(settingsUid)
+          await index.updateSettings(currentIndex.settings)
         }
 
         // Prepare data for indexation
         const transformedData = await currentIndex.transformer(data)
 
-        // Index data to Meilisearch
-        const enqueuedUpdates = await index.addDocumentsInBatches(
-          transformedData,
-          batchSize
-        )
+        const tasks = []
 
-        if (enqueuedUpdates.length === 0) {
-          throw getErrorMsg(
-            'Nothing has been indexed to Meilisearch. Make sure your documents are transformed into an array of objects'
-          )
+        for (let i = 0; i < transformedData.length; i += batchSize) {
+          let documentsActivity = reporter.activityTimer(PLUGIN_NAME)
+          documentsActivity.start()
+          try {
+            const documentsBatch = transformedData.slice(i, i + batchSize)
+            if (documentsBatch.length > 0) {
+              const task = await index.addDocuments(documentsBatch)
+
+              documentsActivity.setStatus(
+                `Adding ${documentsBatch.length} documents to Meilisearch, track the process with the task id : "${task.taskUid}". (doc: https://docs.meilisearch.com/reference/api/tasks.html#get-one-task)`
+              )
+
+              tasks.push(task)
+            }
+          } catch (err) {
+            documentsActivity.setStatus(
+              'Failed to send batch of document to Meilisearch'
+            )
+          }
+          documentsActivity.end()
         }
 
-        // Wait for indexation to be completed
-        for (const enqueuedUpdate of enqueuedUpdates) {
-          await index.waitForTask(enqueuedUpdate.taskUid)
-          const task = await index.getTask(enqueuedUpdate.taskUid)
-
-          if (task.status === 'failed') {
-            throw getErrorMsg(`${task.error?.message} (${task.error?.code})`)
-          }
+        if (tasks.length === 0) {
+          throw getErrorMsg(
+            'No documents have been indexed to Meilisearch. Make sure your documents are transformed into an array of objects'
+          )
         }
       })
     )
-
-    activity.setStatus('Documents added to Meilisearch')
+    activity.setStatus(
+      'Documents are send to Meilisearch, track the indexing progress using the tasks ids.'
+    )
   } catch (err) {
     reporter.error(err.message || err)
     activity.setStatus('Failed to index to Meilisearch')

--- a/tests/index-to-meilisearch.test.js
+++ b/tests/index-to-meilisearch.test.js
@@ -6,6 +6,7 @@ const {
   fakeGraphql,
   fakeReporter,
   clearAllIndexes,
+  waitForLastTask,
 } = require('./utils')
 
 const activity = fakeReporter.activityTimer()
@@ -92,35 +93,7 @@ describe('Index to Meilisearch', () => {
     )
     expect(fakeReporter.error).toHaveBeenCalledTimes(1)
     expect(fakeReporter.error).toHaveBeenCalledWith(
-      '[gatsby-plugin-meilisearch] Nothing has been indexed to Meilisearch. Make sure your documents are transformed into an array of objects'
-    )
-    expect(activity.setStatus).toHaveBeenCalledTimes(1)
-    expect(activity.setStatus).toHaveBeenCalledWith(
-      'Failed to index to Meilisearch'
-    )
-  })
-
-  test('Should fail if there are no primary key in the documents', async () => {
-    const wrongQuery = `
-    query MyQuery {
-      allMdx {
-        edges {
-          node {
-            slug
-          }
-        }
-      }
-    }`
-    await onPostBuild(
-      { graphql: fakeGraphql, reporter: fakeReporter },
-      {
-        ...fakeConfig,
-        indexes: [{ ...fakeConfig.indexes[0], query: wrongQuery }],
-      }
-    )
-    expect(fakeReporter.error).toHaveBeenCalledTimes(1)
-    expect(fakeReporter.error).toHaveBeenCalledWith(
-      `[gatsby-plugin-meilisearch] The primary key inference process failed because the engine did not find any fields containing \`id\` substring in their name. If your document identifier does not contain any \`id\` substring, you can set the primary key of the index. (primary_key_inference_failed)`
+      '[gatsby-plugin-meilisearch] No documents have been indexed to Meilisearch. Make sure your documents are transformed into an array of objects'
     )
     expect(activity.setStatus).toHaveBeenCalledTimes(1)
     expect(activity.setStatus).toHaveBeenCalledWith(
@@ -205,6 +178,8 @@ describe('Index to Meilisearch', () => {
         ],
       }
     )
+    await waitForLastTask(client)
+
     const { results } = await client.getIndexes()
 
     expect(results).toHaveLength(2)
@@ -249,6 +224,8 @@ describe('Index to Meilisearch', () => {
       }
     )
 
+    await waitForLastTask(client)
+
     const firstQueryResult = await client
       .index(fakeConfig.indexes[0].indexUid)
       .search('Axolotl')
@@ -267,6 +244,7 @@ describe('Index to Meilisearch', () => {
         ],
       }
     )
+    await waitForLastTask(client)
 
     const secondQueryResult = await client
       .index(fakeConfig.indexes[0].indexUid)
@@ -280,9 +258,9 @@ describe('Index to Meilisearch', () => {
       { graphql: fakeGraphql, reporter: fakeReporter },
       fakeConfig
     )
-    expect(activity.setStatus).toHaveBeenCalledTimes(1)
-    expect(activity.setStatus).toHaveBeenCalledWith(
-      'Documents added to Meilisearch'
+    expect(activity.setStatus).toHaveBeenCalledTimes(2)
+    expect(activity.setStatus).toHaveBeenLastCalledWith(
+      `Documents are send to Meilisearch, track the indexing progress using the tasks ids.\ndoc: https://docs.meilisearch.com/reference/api/tasks.html#get-one-task`
     )
   })
 })

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -69,9 +69,18 @@ const clearAllIndexes = async config => {
   await client.waitForTasks(taskIds)
 }
 
+const waitForLastTask = async client => {
+  // Fetch the latests created task
+  const task = await client.getTasks({ limit: 1 })
+  // By waiting for the latest task, we ensure that all tasks created before
+  // are going to be `processed` as well.
+  await client.waitForTask(task.results[0].uid)
+}
+
 module.exports = {
   fakeConfig,
   fakeGraphql,
   clearAllIndexes,
   fakeReporter,
+  waitForLastTask,
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #194 

## What does this PR do?
- Remove every use of `wait_for_task` to avoid a timeout and to fasten the build time.
- Add logging providing the tasks uids of every batch of documents send to Meilisearch

Output example:
```
success Delete previous page data - 0.001s
success Send documents to Meilisearch - 0.014s - Adding 10 document(s) to
Meilisearch, task uid : "2063".
success Send documents to Meilisearch - 0.063s - Adding 10 document(s) to
Meilisearch, task uid : "2064".
success Send documents to Meilisearch - 0.059s - Adding 10 document(s) to
Meilisearch, task uid : "2065".
success Send documents to Meilisearch - 0.079s - Adding 10 document(s) to
Meilisearch, task uid : "2066".
success Send documents to Meilisearch - 0.023s - Adding 9 document(s) to
Meilisearch, task uid : "2067".
success gatsby-plugin-meilisearch - 0.350s - Documents are send to Meilisearch,
track the indexing progress using the tasks uids.
```

