### PR TITLE
Fix broken link to Meilisearch documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 ## 📖 Documentation
 
-To understand Meilisearch and how it works, see the [Meilisearch's documentation](https://docs.meilisearch.com/learn/what_is_meilisearch/).
+To understand Meilisearch and how it works, see the [Meilisearch's documentation](https://docs.meilisearch.com/).
 
 To understand Gatsby and how it works, see [Gatsby's documentation](https://www.gatsbyjs.com/docs/tutorial/).
 


### PR DESCRIPTION
The link was not found. Resulting in a 404