### PR TITLE
Update dependabot.yml from ignore to allow rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,9 +20,5 @@ updates:
       - dependencies
     versioning-strategy: increase
     rebase-strategy: disabled
-    ignore:
-      - dependency-name: "eslint*"
-      - dependency-name: "*prettier*"
-      - dependency-name: "*jest*"
-      - dependency-name: "*cypress*"
-      - dependency-name: "*concurrently*"
+    allow:
+      - dependency-name: meilisearch


### PR DESCRIPTION
Avoid being spammed with dependencies updates by changing from an ignore list to an allow list